### PR TITLE
Correct explanation for called_with kwargs only

### DIFF
--- a/robber/matchers/mock_mixin.py
+++ b/robber/matchers/mock_mixin.py
@@ -12,22 +12,26 @@ class MockMixin:
 
     @property
     def expected_args_str(self):
-        if not self.expected:
+        if not self.expected and not self.kwargs:
             return 'no arguments'
 
-        expected_args_str = str(self.expected)
+        expected_args = []
+
+        if self.expected:
+            expected_args = [str(self.expected)]
+
         if self.args:
             # Remove the parenthesis
             match = re.search('\((.*)\)', str(self.args))
-            args_str = match.group(1)
-            expected_args_str = ', '.join((expected_args_str, args_str))
+            expected_args.append(match.group(1))
 
         if self.kwargs:
             # Convert {'a':  1, 'b': 2} to 'a=1, b=2'
             kwargs_str = ', '.join(['{0}={1!r}'.format(k, v) for k, v in self.kwargs.items()])
-            expected_args_str = ', '.join((expected_args_str, kwargs_str))
 
-        return expected_args_str
+            expected_args.append(kwargs_str)
+
+        return ', '.join(expected_args)
 
     @property
     def call_args_str(self):

--- a/tests/matchers/test_mock_mixin.py
+++ b/tests/matchers/test_mock_mixin.py
@@ -52,6 +52,11 @@ class TestExpectedArgs(TestCase):
         dummy_matcher = DummyMockMatcher(Mock(), 1, False, 2, 'a')
         expect(dummy_matcher.expected_args_str).to.eq("1, 2, 'a'")
 
+    def test_with_only_kwargs(self):
+        dummy_matcher = DummyMockMatcher(Mock(), a='a')
+
+        expect(dummy_matcher.expected_args_str).to.eq("a='a'")
+
     def test_with_expected_and_kwargs(self):
         dummy_matcher = DummyMockMatcher(Mock(), 1, False, a='a', one=1)
         split_expected_args = dummy_matcher.expected_args_str.split(', ')


### PR DESCRIPTION
### Description

When the `CalledWith` expectation is used with only `kwargs` and fails
the explanation is *always* indicates that no arguments were expected,
even when they were.


### Usage

A simple example to show the problem:
```
from robber import expect
from patch import Mock

mock = Mock(bar='foo')

expect(mock).to.be.called_with(foo='bar')
```
will output 
```
A = <Mock id='some_id'>
B = no arguments
Z = foo='baz'
Expected A to be called with B
Actually called with Z
```
When it should output:
```
A = <Mock id='4447809232'>
B = foo='bar'
Z = foo='baz'
Expected A to be called with B
Actually called with Z
```

### Changes
Account for this case when composing the explanation for `MockMixin`

### Notes

Just thanks for making this great library!