### PR TITLE
Fix chaining to work and still print True/False

### DIFF
--- a/robber/expect.py
+++ b/robber/expect.py
@@ -24,6 +24,9 @@ class expect:
         self.not_to_flag = False
         self.__setup_chaining()
 
+    def __repr__(self):
+        return str(isinstance(self, expect))
+
     @classmethod
     def fail_with(cls, message):
         cls.message = message

--- a/robber/matchers/base.py
+++ b/robber/matchers/base.py
@@ -1,4 +1,5 @@
 from robber.bad_expectation import BadExpectation
+from robber.expect import expect
 
 
 class Base:
@@ -23,7 +24,7 @@ class Base:
 
     def match(self):
         if self.matches() is not self.is_negative:
-            return True
+            return expect(self.actual)
 
         message = self.message or self.explanation.message
         raise BadExpectation(message)

--- a/tests/matchers/test_base.py
+++ b/tests/matchers/test_base.py
@@ -9,8 +9,8 @@ class TestBase(unittest.TestCase):
     def test_it_stores_actual_and_expected(self):
         base = Base('actual', 'expected')
 
-        expect(base.actual) == 'actual'
-        expect(base.expected) == 'expected'
+        expect(base.actual).to.eq('actual')
+        expect(base.expected).to.eq('expected')
 
     def test_it_calls_matches(self):
         matcher = TestWillMatch('actual', 'expected')
@@ -36,4 +36,4 @@ class TestBase(unittest.TestCase):
 
     def test_match(self):
         matcher = TestWillMatch('actual', 'expected')
-        expect(matcher.match()).to.eq(True)
+        expect(matcher.match()).to.eq('actual')

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -44,6 +44,9 @@ class TestExpectation(unittest.TestCase):
         expectation = expect(object)
         expect(expectation.to).to.equal(expectation.to.be)
 
+    def test_chaining_readme(self):
+        expect(1 + 1).to.be.an.integer().to.be.within(1, 3)
+
     def test_multiple_not_to_success(self):
         expect(1).eq(1)
         expect(1).not_to.not_to.eq(1)


### PR DESCRIPTION
### Description

Currently, chaining does not work per the README as the match returns a boolean instead of an
expect.  This fixes it to still work with multiple expects, while still allowing for True/False to be printed via an interactive prompt

### Examples

Current code, on a prompt:
```
>>> from robber import expect
>>> expect(1 + 1).to.be.an.integer()
True
>>> expect(1 + 1).to.be.an.integer().within(1,3)
AttributeError: 'bool' object has no attribute 'within'
>>> expect(1 + 1).to.be.an.integer().within(5,10)
AttributeError: 'bool' object has no attribute 'within'
```

With this PR:
```
>>> from robber import expect
>>> expect(1 + 1).to.be.an.integer()
True
>>> expect(1 + 1).to.be.an.integer().within(1,3)
True
>>> expect(1 + 1).to.be.an.integer().within(5,10)
robber.bad_expectation.BadExpectation:
A = 2
B = 5
C = 10
Expected A to be within B and C
```

